### PR TITLE
Add fallback on macos to get peripherals from the system

### DIFF
--- a/bluetooth_low_energy_darwin/darwin/Classes/MyError.swift
+++ b/bluetooth_low_energy_darwin/darwin/Classes/MyError.swift
@@ -11,4 +11,5 @@ enum MyError: Error {
     case unknown
     case unsupported
     case illegalArgument
+    case invalidPeripheral
 }


### PR DESCRIPTION
This allows to connect to peripherals by address without having to discover them first meaning that a known device address can be saved by an application for reconnection later