### PR TITLE
[Android] Allow direct connection by MAC address

### DIFF
--- a/bluetooth_low_energy_android/android/src/main/kotlin/dev/hebei/bluetooth_low_energy_android/MyCentralManager.kt
+++ b/bluetooth_low_energy_android/android/src/main/kotlin/dev/hebei/bluetooth_low_energy_android/MyCentralManager.kt
@@ -168,7 +168,7 @@ class MyCentralManager(context: Context, binaryMessenger: BinaryMessenger) : MyB
 
     override fun connect(addressArgs: String, callback: (Result<Unit>) -> Unit) {
         try {
-            val device = mDevices[addressArgs] ?: throw IllegalArgumentException()
+            val device = mDevices[addressArgs] ?: adapter.getRemoteDevice(addressArgs.substringAfterLast("-"))
             val autoConnect = false // Add to bluetoothGATTs cache.
             mGATTs[addressArgs] = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 val transport = BluetoothDevice.TRANSPORT_LE


### PR DESCRIPTION
This single line change allows to connect directly to known device by mac address.

Fixes issue #64 