### PR TITLE
iOS: Fix race condition when isReady is delivered early

### DIFF
--- a/bluetooth_low_energy_darwin/lib/src/my_peripheral_manager.dart
+++ b/bluetooth_low_energy_darwin/lib/src/my_peripheral_manager.dart
@@ -73,6 +73,8 @@ final class MyPeripheralManager extends PlatformPeripheralManager
       );
   Stream<EventArgs> get _isReady => _isReadyController.stream;
 
+  bool isReadyDeliveredEarly = false;
+
   @override
   void initialize() {
     MyPeripheralManagerFlutterAPI.setUp(this);
@@ -217,7 +219,11 @@ final class MyPeripheralManager extends PlatformPeripheralManager
       if (updated) {
         break;
       }
-      await _isReady.first;
+      if (isReadyDeliveredEarly) {
+          isReadyDeliveredEarly = false;
+      } else {
+          await _isReady.first;
+      }
     }
   }
 
@@ -309,7 +315,11 @@ final class MyPeripheralManager extends PlatformPeripheralManager
   @override
   void isReady() {
     final eventArgs = EventArgs();
-    _isReadyController.add(eventArgs);
+    if (!_isReadyController.hasListener) {
+        isReadyDeliveredEarly = true;
+    } else {
+        _isReadyController.add(eventArgs);
+    }
   }
 
   @override


### PR DESCRIPTION
Under iOS when sending lots of characteristic notifications / indications, the [`CBPeripheralManager.updateValue()`](https://developer.apple.com/documentation/corebluetooth/cbperipheralmanager/updatevalue(_:for:onsubscribedcentrals:)) function will sometimes return `false`:

> This value is [true](https://developer.apple.com/documentation/swift/true) if the update is successfully sent to the subscribed central or centrals. [false](https://developer.apple.com/documentation/swift/false) if the update isn’t successfully sent because the underlying transmit queue is full.

The documentation mentions that [`CBPeripheralManagerDelegate. peripheralManagerIsReady(toUpdateSubscribers:)`](https://developer.apple.com/documentation/corebluetooth/cbperipheralmanagerdelegate/peripheralmanagerisready(toupdatesubscribers:)) is called when the `updateValue()` call can be retried.

This is implemented in `bluetooth_low_energy` on the Dart side here:

https://github.com/yanshouwang/bluetooth_low_energy/blob/cbeb09d0af78ef3bffe93ea35e7d4970309e995f/bluetooth_low_energy_darwin/lib/src/my_peripheral_manager.dart#L200-L222

Take notice of the `await _isReady.first;` to wait for the opportunity to re-send, which will become relevant again later.

The `_api.updateValue()` call ends up on the Swift side here:

https://github.com/yanshouwang/bluetooth_low_energy/blob/cbeb09d0af78ef3bffe93ea35e7d4970309e995f/bluetooth_low_energy_darwin/darwin/Classes/MyPeripheralManager.swift#L166-L179

If `mPeripheralManager.updateValue()` returns `false`, eventually (as per iOS CoreBluetooth specs) the delegate will be called:

https://github.com/yanshouwang/bluetooth_low_energy/blob/cbeb09d0af78ef3bffe93ea35e7d4970309e995f/bluetooth_low_energy_darwin/darwin/Classes/MyPeripheralManagerDelegate.swift#L46-L48

This call is then forwarded to the Dart code here:

https://github.com/yanshouwang/bluetooth_low_energy/blob/cbeb09d0af78ef3bffe93ea35e7d4970309e995f/bluetooth_low_energy_darwin/darwin/Classes/MyPeripheralManager.swift#L283-L285

The Dart code receives this call:

https://github.com/yanshouwang/bluetooth_low_energy/blob/cbeb09d0af78ef3bffe93ea35e7d4970309e995f/bluetooth_low_energy_darwin/lib/src/my_peripheral_manager.dart#L309-L313

The `_isReadyController` is a broadcast stream controller:

https://github.com/yanshouwang/bluetooth_low_energy/blob/cbeb09d0af78ef3bffe93ea35e7d4970309e995f/bluetooth_low_energy_darwin/lib/src/my_peripheral_manager.dart#L35

Broadcast stream controllers have the following property, as [described in the documentation](https://api.dart.dev/dart-async/StreamController/StreamController.broadcast.html):

> Broadcast streams do not buffer events when there is no listener.

Now, the following order of events usually happens:

 1. Library user calls `notifyCharacteristic()`
 2. The `mPeripheralManager.updateValue()` call in Swift returns `false`
 3. The Dart code calls `await _isReady.first;`
 4. Eventually, iOS calls `peripheralManagerIsReady(toUpdateSubscribers:)`
 5. The `isReady` function in Dart is called, doing `_isReadyController.add(eventArgs);`
 6. The `await _isReady.first` call returns
 7. `updateValue()` is called again in the loop

However, the following order of events is also possible / has been observed (at least with iOS 18.6 on an iPhone 12 mini):

 1. Library user calls `notifyCharacteristic()`
 2. The `mPeripheralManager.updateValue()` call in Swift returns `false`
 3. iOS calls `peripheralManagerIsReady(toUpdateSubscribers:)`
 4. The `isReady` function in Dart is called, doing `_isReadyController.add(eventArgs);` (**this event is thrown away, as there is no listener**)
 5. Only afterwards, the Dart code calls `await _isReady.first;`
 6. The `await _isReady.first` call never returns, as no `_isReadyController.add(eventArgs);` calls are made
 7. The loop blocks forever

Note that this doesn't always happen, but if it does (best with a loop that calls `notifyCharacteristic()`), the library call locks up and never returns.

The submitted patch tries to work around this issue by checking for `_isReadyController.hasListener` -- if it doesn't have any listeners, it just sets a flag (`isReadyDeliveredEarly`), and if that flag is set, the loop in `notifyCharacteristic()` won't bother `await`ing on the `_isReady` stream.

Ideally, there would be a way to have `notifyCharacteristic()` return a `bool` immediately if `updateValue()` returns `false`, and have a way to listen to `isReady` from a library caller (so the library caller can handle queueing, and might decide NOT to retry sending an event if it isn't sent immediately), but that would require more intrusive changes.