### PR TITLE
feat(android): add central write flow control for burst characteristic writes

### DIFF
--- a/bluetooth_low_energy_android/android/src/main/kotlin/dev/zeekr/bluetooth_low_energy_android/CentralManagerImpl.kt
+++ b/bluetooth_low_energy_android/android/src/main/kotlin/dev/zeekr/bluetooth_low_energy_android/CentralManagerImpl.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.os.ParcelUuid
 import android.provider.Settings
 import androidx.annotation.RequiresPermission
@@ -15,6 +17,16 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityOptionsCompat
 import androidx.core.content.ContextCompat
 import io.flutter.plugin.common.BinaryMessenger
+import java.util.ArrayDeque
+
+private data class PendingCharacteristicWriteRequest(
+    val addressArgs: String,
+    val hashCodeArgs: Long,
+    val valueArgs: ByteArray,
+    val typeArgs: GATTCharacteristicWriteTypeArgs,
+    val callback: ((Result<Unit>) -> Unit)? = null,
+    val retryCount: Int = 0,
+)
 
 class CentralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) : BluetoothLowEnergyManagerImpl(context),
     CentralManagerHostApi {
@@ -41,6 +53,9 @@ class CentralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) : B
     private val mWriteCharacteristicCallbacks: MutableMap<String, MutableMap<Long, (Result<Unit>) -> Unit>>
     private val mReadDescriptorCallbacks: MutableMap<String, MutableMap<Long, (Result<ByteArray>) -> Unit>>
     private val mWriteDescriptorCallbacks: MutableMap<String, MutableMap<Long, (Result<Unit>) -> Unit>>
+    private val mPendingCharacteristicWriteRequests: MutableMap<String, ArrayDeque<PendingCharacteristicWriteRequest>>
+    private val mActiveCharacteristicWriteRequests: MutableMap<String, PendingCharacteristicWriteRequest>
+    private val mWriteDrainHandler: Handler = Handler(Looper.getMainLooper())
 
     init {
         mApi = CentralManagerFlutterApi(binaryMessenger)
@@ -63,7 +78,12 @@ class CentralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) : B
         mWriteCharacteristicCallbacks = mutableMapOf()
         mReadDescriptorCallbacks = mutableMapOf()
         mWriteDescriptorCallbacks = mutableMapOf()
+        mPendingCharacteristicWriteRequests = mutableMapOf()
+        mActiveCharacteristicWriteRequests = mutableMapOf()
     }
+
+    private val withoutResponseWriteIntervalMs = 4L
+    private val maxWithoutResponseRetryCount = 6
 
     private val permissions: Array<String>
         get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -105,6 +125,8 @@ class CentralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) : B
         mWriteCharacteristicCallbacks.clear()
         mReadDescriptorCallbacks.clear()
         mWriteDescriptorCallbacks.clear()
+        mPendingCharacteristicWriteRequests.clear()
+        mActiveCharacteristicWriteRequests.clear()
 
         val enableNotificationValue = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
         val enableIndicationValue = BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
@@ -279,22 +301,22 @@ class CentralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) : B
         callback: (Result<Unit>) -> Unit
     ) {
         try {
-            val gatt = mGATTs[addressArgs] ?: throw IllegalArgumentException()
-            val characteristic = retrieveCharacteristic(addressArgs, hashCodeArgs)
-            val type = typeArgs.toType()
-            val writing = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                val code = gatt.writeCharacteristic(characteristic, valueArgs, type)
-                code == BluetoothStatusCodes.SUCCESS
-            } else { // TODO: remove this when minSdkVersion >= 33
-                characteristic.value = valueArgs
-                characteristic.writeType = type
-                gatt.writeCharacteristic(characteristic)
+            mGATTs[addressArgs] ?: throw IllegalArgumentException()
+            retrieveCharacteristic(addressArgs, hashCodeArgs)
+
+            val request = PendingCharacteristicWriteRequest(
+                addressArgs = addressArgs,
+                hashCodeArgs = hashCodeArgs,
+                valueArgs = valueArgs,
+                typeArgs = typeArgs,
+                callback = if (typeArgs == GATTCharacteristicWriteTypeArgs.WITHOUT_RESPONSE) null else callback,
+            )
+            if (typeArgs == GATTCharacteristicWriteTypeArgs.WITHOUT_RESPONSE) {
+                callback(Result.success(Unit))
             }
-            if (!writing) {
-                throw IllegalStateException()
-            }
-            val callbacks = mWriteCharacteristicCallbacks.getOrPut(addressArgs) { mutableMapOf() }
-            callbacks[hashCodeArgs] = callback
+            val queue = mPendingCharacteristicWriteRequests.getOrPut(addressArgs) { ArrayDeque() }
+            queue.addLast(request)
+            drainCharacteristicWrites(addressArgs)
         } catch (e: Throwable) {
             callback(Result.failure(e))
         }
@@ -433,6 +455,7 @@ class CentralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) : B
                     callback(Result.failure(error))
                 }
             }
+            failPendingCharacteristicWrites(addressArgs, error)
             val readDescriptorCallbacks = mReadDescriptorCallbacks.remove(addressArgs)
             if (readDescriptorCallbacks != null) {
                 val callbacks = readDescriptorCallbacks.values
@@ -539,6 +562,20 @@ class CentralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) : B
     fun onCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
         val device = gatt.device
         val addressArgs = device.address
+        val activeRequest = mActiveCharacteristicWriteRequests.remove(addressArgs)
+        if (activeRequest != null) {
+            val callback = activeRequest.callback
+            if (callback != null) {
+                if (status == BluetoothGatt.GATT_SUCCESS) {
+                    callback(Result.success(Unit))
+                } else {
+                    val error = IllegalStateException("Write characteristic failed with status: $status.")
+                    callback(Result.failure(error))
+                }
+            }
+            drainCharacteristicWrites(addressArgs)
+            return
+        }
         val hashCodeArgs = characteristic.hashCode.args
         val callbacks = mWriteCharacteristicCallbacks[addressArgs] ?: return
         val callback = callbacks.remove(hashCodeArgs) ?: return
@@ -608,5 +645,73 @@ class CentralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) : B
     private fun retrieveDescriptor(addressArgs: String, hashCodeArgs: Long): BluetoothGattDescriptor {
         val descriptors = mDescriptors[addressArgs] ?: throw IllegalArgumentException()
         return descriptors[hashCodeArgs] ?: throw IllegalArgumentException()
+    }
+
+    @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
+    private fun drainCharacteristicWrites(addressArgs: String) {
+        if (mActiveCharacteristicWriteRequests.containsKey(addressArgs)) {
+            return
+        }
+        val queue = mPendingCharacteristicWriteRequests[addressArgs] ?: return
+        if (queue.isEmpty()) {
+            return
+        }
+        val request = queue.removeFirst()
+        val gatt = mGATTs[request.addressArgs]
+        if (gatt == null) {
+            request.callback?.invoke(Result.failure(IllegalStateException("GATT is not connected.")))
+            drainCharacteristicWrites(addressArgs)
+            return
+        }
+        val characteristic = retrieveCharacteristic(request.addressArgs, request.hashCodeArgs)
+        val type = request.typeArgs.toType()
+        val writing = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val code = gatt.writeCharacteristic(characteristic, request.valueArgs, type)
+            code == BluetoothStatusCodes.SUCCESS
+        } else { // TODO: remove this when minSdkVersion >= 33
+            characteristic.value = request.valueArgs
+            characteristic.writeType = type
+            gatt.writeCharacteristic(characteristic)
+        }
+
+        if (!writing) {
+            if (request.typeArgs == GATTCharacteristicWriteTypeArgs.WITHOUT_RESPONSE &&
+                request.retryCount < maxWithoutResponseRetryCount
+            ) {
+                queue.addFirst(request.copy(retryCount = request.retryCount + 1))
+                scheduleWithoutResponseDrain(addressArgs)
+                return
+            }
+            request.callback?.invoke(Result.failure(IllegalStateException("Write characteristic enqueue failed.")))
+            drainCharacteristicWrites(addressArgs)
+            return
+        }
+
+        mActiveCharacteristicWriteRequests[addressArgs] = request
+        if (request.typeArgs == GATTCharacteristicWriteTypeArgs.WITHOUT_RESPONSE) {
+            scheduleWithoutResponseDrain(addressArgs)
+        }
+    }
+
+    private fun scheduleWithoutResponseDrain(addressArgs: String) {
+        mWriteDrainHandler.postDelayed({
+            val activeRequest = mActiveCharacteristicWriteRequests[addressArgs]
+            if (activeRequest != null &&
+                activeRequest.typeArgs == GATTCharacteristicWriteTypeArgs.WITHOUT_RESPONSE
+            ) {
+                mActiveCharacteristicWriteRequests.remove(addressArgs)
+            }
+            drainCharacteristicWrites(addressArgs)
+        }, withoutResponseWriteIntervalMs)
+    }
+
+    private fun failPendingCharacteristicWrites(addressArgs: String, error: Throwable) {
+        val activeRequest = mActiveCharacteristicWriteRequests.remove(addressArgs)
+        activeRequest?.callback?.invoke(Result.failure(error))
+        val queue = mPendingCharacteristicWriteRequests.remove(addressArgs) ?: return
+        while (queue.isNotEmpty()) {
+            val request = queue.removeFirst()
+            request.callback?.invoke(Result.failure(error))
+        }
     }
 }


### PR DESCRIPTION
## Background
- This PR targets Android central-side characteristic writes in `bluetooth_low_energy_android`.
- Reproduced against `bluetooth_low_energy_android 6.2.1` and upstream `master` as checked on March 14, 2026.
- Today, burst `writeWithoutResponse` traffic is forwarded directly to `BluetoothGatt.writeCharacteristic(...)` with no Android-side flow control in `CentralManagerImpl`.
- A real workload that exposed this was collaborative drawing, where the Android central sends many small stroke batches in quick succession.
- I am narrowing this PR to Android-internal queueing only, without proposing a new public API.

## Core changes
### Android implementation
- Add Android-side flow control for central characteristic writes in `CentralManagerImpl`.
- Serialize writes per peripheral instead of letting burst traffic race directly into the Android stack.
- Track pending and active writes so the Android layer can absorb short-lived backpressure instead of surfacing every temporary busy state to the caller immediately.
- Clear active/pending write state during disconnect and re-initialization so queued writes do not leak across connection lifecycle events.

### Dart / public API
- Keep the public Dart API unchanged.
- Keep the change Android-only in the first step.

### Out of scope
- No new cross-platform API.
- No application-level batching or chunk sizing changes.
- No PeripheralManager notification flow-control changes.

## User-visible behavior
- Before: burst `writeWithoutResponse` traffic is sent directly into the Android stack with no plugin-level queueing.
- After: burst writes are serialized per peripheral inside the Android implementation.

## Validation
- [x] `flutter analyze third_party/bluetooth_low_energy_android/lib`
- [ ] Android native automated test
- [x] Manual Android validation with a burst-write workload from `little_palette`
- Manual check: a burst-write workload from `little_palette` no longer depends entirely on app-side pacing.
- Manual check: disconnect/reset clears Android-side write state cleanly.

## Risks and rollback
- Risk: this changes Android-side write scheduling, especially for `writeWithoutResponse`.
- Risk: Android callback ordering for burst writes can be subtle, so the implementation must avoid double-drain or duplicate completion paths.
- Rollback: revert the Android-only `CentralManagerImpl` changes.

## Related issue
- Related to #152
- Closes #152

## Reviewer notes
- I would appreciate guidance on two points:
1. Is Android-internal queueing for central writes acceptable as a first step while keeping the Dart API unchanged?
2. For Android `writeWithoutResponse`, should this PR preserve the current `Future<void>` behavior exactly, or would you prefer a follow-up that exposes more explicit flow-control semantics?
