### PR TITLE
fix(darwin): Respect short service UUIDs in advertisement, fix #154

### DIFF
--- a/bluetooth_low_energy_darwin/lib/src/api.dart
+++ b/bluetooth_low_energy_darwin/lib/src/api.dart
@@ -133,7 +133,16 @@ extension CentralArgsX on CentralArgs {
 // ToArgs
 extension UUIDX on UUID {
   String toArgs() {
-    return toString();
+    final str = toString();
+    if (!isShort) {
+      return str;
+    }
+    // For 16-bit UUIDs (first two bytes are 0x00), return 4-char short form.
+    if (value[0] == 0x00 && value[1] == 0x00) {
+      return str.substring(4, 8);
+    }
+    // For 32-bit UUIDs, return 8-char short form.
+    return str.substring(0, 8);
   }
 }
 


### PR DESCRIPTION
This pull request updates the logic for converting `UUID` objects to argument strings in the `UUIDX` extension. The new implementation improves how short forms of UUIDs are generated, especially for 16-bit and 32-bit UUIDs.

UUID short form handling:

* Updated the `toArgs` method in the `UUIDX` extension to return a 4-character short form for 16-bit UUIDs (when the first two bytes are `0x00`), and an 8-character short form for 32-bit UUIDs; otherwise, returns the full string representation. (`bluetooth_low_energy_darwin/lib/src/api.dart`)Pass 16-bit and 32-bit short UUID strings to CoreBluetooth instead of always sending full 128-bit UUIDs, so CBUUID objects are created with the correct short form in advertisement packets.