### PR TITLE
fix(android): startAdvertising hangs on subsequent calls, fix #89 

### DIFF
--- a/bluetooth_low_energy_android/android/src/main/kotlin/dev/zeekr/bluetooth_low_energy_android/PeripheralManagerImpl.kt
+++ b/bluetooth_low_energy_android/android/src/main/kotlin/dev/zeekr/bluetooth_low_energy_android/PeripheralManagerImpl.kt
@@ -154,6 +154,10 @@ class PeripheralManagerImpl(context: Context, binaryMessenger: BinaryMessenger) 
     @RequiresPermission(Manifest.permission.BLUETOOTH_CONNECT)
     override fun setName(nameArgs: String, callback: (Result<String?>) -> Unit) {
         try {
+            if (adapter.name == nameArgs) {
+                callback(Result.success(nameArgs))
+                return
+            }
             val setting = adapter.setName(nameArgs)
             if (!setting) {
                 throw IllegalStateException()

--- a/bluetooth_low_energy_darwin/lib/src/api.dart
+++ b/bluetooth_low_energy_darwin/lib/src/api.dart
@@ -133,7 +133,16 @@ extension CentralArgsX on CentralArgs {
 // ToArgs
 extension UUIDX on UUID {
   String toArgs() {
-    return toString();
+    final str = toString();
+    if (!isShort) {
+      return str;
+    }
+    // For 16-bit UUIDs (first two bytes are 0x00), return 4-char short form.
+    if (value[0] == 0x00 && value[1] == 0x00) {
+      return str.substring(4, 8);
+    }
+    // For 32-bit UUIDs, return 8-char short form.
+    return str.substring(0, 8);
   }
 }
 


### PR DESCRIPTION
This pull request introduces targeted improvements to both the Android and Darwin (iOS/macOS) implementations for Bluetooth Low Energy (BLE) functionality. The changes focus on optimizing BLE device name handling on Android and standardizing UUID string representations on Darwin platforms.

**Android BLE enhancements:**

* Improved the `setName` method in `PeripheralManagerImpl` to immediately return success if the adapter's name is already set to the desired value, avoiding unnecessary operations.

**Darwin BLE UUID formatting:**

* Updated the `UUIDX.toArgs()` extension in `api.dart` to return a short-form string for 16-bit and 32-bit UUIDs, ensuring consistent and concise UUID representations when communicating with native code.